### PR TITLE
Resolve relative import map URLs to absolute for TypeScript LSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,15 @@ And then run `npx meta dev` and open `http://localhost:3000`.
 You can configure the playground by passing a configuration object to the `playgroundPreset` function. Have a look at [the demo](https://github.com/studiometa/playground/blob/main/packages/demo/meta.config.js) for all available options.
 
 When you are ready, run `npx meta build` and you can deploy the generated `dist/` folder to any static hosting of your choice.
+
+### Import Map
+
+Relative paths in the `importMap` option are automatically resolved to absolute URLs at runtime using `window.location.origin`. This allows build tools to use natural relative paths:
+
+```js
+playgroundPreset({
+  importMap: {
+    '@studiometa/js-toolkit': '/static/js-toolkit/index.js',
+  },
+})
+```

--- a/packages/playground/src/front/js/components/Iframe.ts
+++ b/packages/playground/src/front/js/components/Iframe.ts
@@ -8,6 +8,7 @@ import {
   getTransformedStyle as getStyle,
   getTransformedScript as getScript,
 } from '../store/index.js';
+import { resolveImportMapUrls } from '../utils/resolve-import-map-urls.js';
 
 type esbuildType = typeof import('esbuild-wasm');
 
@@ -145,7 +146,7 @@ ${html}
     const importMap = this.doc.createElement('script');
     importMap.type = 'importmap';
     importMap.textContent = JSON.stringify({
-      imports: this.$options.importMap,
+      imports: resolveImportMapUrls(this.$options.importMap),
     });
     this.doc.head.append(importMap);
   }

--- a/packages/playground/src/front/js/components/ScriptEditor.ts
+++ b/packages/playground/src/front/js/components/ScriptEditor.ts
@@ -1,5 +1,6 @@
 import type { InitOptions } from 'modern-monaco';
 import { getScript, setScript } from '../store/index.js';
+import { resolveImportMapUrls } from '../utils/resolve-import-map-urls.js';
 import Editor from './Editor.js';
 
 export default class ScriptEditor extends Editor {
@@ -35,7 +36,7 @@ export default class ScriptEditor extends Editor {
     return {
       typescript: {
         importMap: {
-          imports: importMap,
+          imports: resolveImportMapUrls(importMap),
           scopes: {},
         },
       },

--- a/packages/playground/src/front/js/utils/__tests__/resolve-import-map-urls.test.ts
+++ b/packages/playground/src/front/js/utils/__tests__/resolve-import-map-urls.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { resolveImportMapUrls } from '../resolve-import-map-urls.js';
+
+describe('resolveImportMapUrls', () => {
+  const origin = 'https://example.com';
+
+  it('resolves relative paths to absolute URLs', () => {
+    const map = { 'foo': '/static/foo.js' };
+    expect(resolveImportMapUrls(map, origin)).toEqual({
+      'foo': 'https://example.com/static/foo.js',
+    });
+  });
+
+  it('leaves absolute URLs unchanged', () => {
+    const map = { 'deepmerge': 'https://esm.sh/deepmerge' };
+    expect(resolveImportMapUrls(map, origin)).toEqual({
+      'deepmerge': 'https://esm.sh/deepmerge',
+    });
+  });
+
+  it('handles trailing-slash specifiers', () => {
+    const map = { '@studiometa/': 'https://esm.sh/@studiometa/' };
+    expect(resolveImportMapUrls(map, origin)).toEqual({
+      '@studiometa/': 'https://esm.sh/@studiometa/',
+    });
+  });
+
+  it('resolves mixed relative and absolute URLs', () => {
+    const map = {
+      '@studiometa/js-toolkit': '/static/js-toolkit/index.js',
+      'deepmerge': 'https://esm.sh/deepmerge',
+    };
+    expect(resolveImportMapUrls(map, origin)).toEqual({
+      '@studiometa/js-toolkit': 'https://example.com/static/js-toolkit/index.js',
+      'deepmerge': 'https://esm.sh/deepmerge',
+    });
+  });
+
+  it('returns empty object for empty input', () => {
+    expect(resolveImportMapUrls({}, origin)).toEqual({});
+  });
+
+  it('uses provided origin over globalThis', () => {
+    const map = { 'foo': '/bar.js' };
+    expect(resolveImportMapUrls(map, 'https://custom.dev')).toEqual({
+      'foo': 'https://custom.dev/bar.js',
+    });
+  });
+});

--- a/packages/playground/src/front/js/utils/resolve-import-map-urls.ts
+++ b/packages/playground/src/front/js/utils/resolve-import-map-urls.ts
@@ -1,0 +1,16 @@
+/**
+ * Resolve relative import map URLs to absolute using the current origin.
+ * modern-monaco's TypeScript worker uses `file:///` as its base URL,
+ * so relative paths must be resolved to absolute `https://` URLs.
+ */
+export function resolveImportMapUrls(
+  importMap: Record<string, string>,
+  origin?: string,
+): Record<string, string> {
+  const base = origin ?? globalThis.location?.origin ?? '';
+  const resolved: Record<string, string> = {};
+  for (const [key, value] of Object.entries(importMap)) {
+    resolved[key] = value.startsWith('/') ? base + value : value;
+  }
+  return resolved;
+}


### PR DESCRIPTION
## Summary

Fixes the issue where relative paths in the `importMap` option (e.g. `/play/static/js-toolkit/index.js`) were resolved against `file:///` by modern-monaco's TypeScript worker, making it impossible to fetch types.

## Changes

- **New utility**: `resolveImportMapUrls()` in `packages/playground/src/front/js/utils/resolve-import-map-urls.ts`
  - Prepends `window.location.origin` to values starting with `/`
  - Leaves absolute URLs unchanged
- **ScriptEditor**: uses `resolveImportMapUrls()` in `getLspOptions()` to pass absolute URLs to the TypeScript LSP
- **Iframe**: uses `resolveImportMapUrls()` in `initImportMaps()` for browser-side module resolution
- **Tests**: 6 test cases covering relative paths, absolute URLs, trailing-slash specifiers, mixed maps, empty input, and origin override
- **README**: added Import Map section

## Link

Closes #47