### PR TITLE
Resolve opaque srcdoc base for new URL() in the preview iframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Resolve the opaque `about:srcdoc` base in the preview iframe so `new URL('/some-path', window.location.href)` no longer throws `Invalid URL` ([#71](https://github.com/studiometa/playground/pull/71), [c04bca9](https://github.com/studiometa/playground/commit/c04bca9))
+
 ## v0.3.8 - 2026.04.03
 
 ### Fixed

--- a/packages/playground/src/front/js/components/Iframe.ts
+++ b/packages/playground/src/front/js/components/Iframe.ts
@@ -9,6 +9,7 @@ import {
   getTransformedScript as getScript,
 } from '../store/index.js';
 import { resolveImportMapUrls } from '../utils/resolve-import-map-urls.js';
+import { createPatchedUrl } from '../utils/patch-iframe-url.js';
 
 type esbuildType = typeof import('esbuild-wasm');
 
@@ -77,6 +78,13 @@ export default class Iframe extends Base<IframeProps> {
     // Enable dev mode in render
     // @ts-expect-error Enable dev mode.
     this.window.__DEV__ = true;
+
+    // The iframe renders from `srcdoc`, so its `window.location.href` is `about:srcdoc`.
+    // This breaks `new URL('/some-path', window.location.href)`. `window.location` is
+    // unforgeable and cannot be mocked, so patch the iframe's `URL` global instead to
+    // resolve the opaque base against a real origin.
+    const iframeWindow = this.window as Window & typeof globalThis;
+    iframeWindow.URL = createPatchedUrl(iframeWindow.URL);
 
     const html = await getHtml();
     this.doc.documentElement.innerHTML = `

--- a/packages/playground/src/front/js/utils/patch-iframe-url.test.ts
+++ b/packages/playground/src/front/js/utils/patch-iframe-url.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { createPatchedUrl } from './patch-iframe-url.js';
+
+describe('createPatchedUrl', () => {
+  const PatchedURL = createPatchedUrl(URL);
+
+  it('rewrites an about:srcdoc base to the fallback base', () => {
+    expect(new PatchedURL('/some-path', 'about:srcdoc').href).toBe('http://localhost/some-path');
+  });
+
+  it('rewrites an about:blank base to the fallback base', () => {
+    expect(new PatchedURL('/some-path', 'about:blank').href).toBe('http://localhost/some-path');
+  });
+
+  it('normalizes a location-like object base via String()', () => {
+    const location = { toString: () => 'about:srcdoc' };
+    expect(new PatchedURL('/some-path', location as unknown as string).href).toBe(
+      'http://localhost/some-path',
+    );
+  });
+
+  it('uses a custom fallback base when provided', () => {
+    const Custom = createPatchedUrl(URL, 'https://example.dev/');
+    expect(new Custom('/foo', 'about:srcdoc').href).toBe('https://example.dev/foo');
+  });
+
+  it('leaves a real absolute base untouched', () => {
+    expect(new PatchedURL('/foo', 'https://studiometa.fr').href).toBe('https://studiometa.fr/foo');
+  });
+
+  it('leaves an absolute url without base untouched', () => {
+    expect(new PatchedURL('https://studiometa.fr/foo').href).toBe('https://studiometa.fr/foo');
+  });
+
+  it('still throws for a truly invalid url', () => {
+    expect(() => new PatchedURL('/foo')).toThrow();
+  });
+
+  it('is an instance of the native URL', () => {
+    expect(new PatchedURL('/foo', 'about:srcdoc')).toBeInstanceOf(URL);
+  });
+
+  describe('static parse', () => {
+    it('rewrites an about:srcdoc base', () => {
+      expect(PatchedURL.parse('/some-path', 'about:srcdoc')?.href).toBe(
+        'http://localhost/some-path',
+      );
+    });
+
+    it('returns null for an invalid url instead of throwing', () => {
+      expect(PatchedURL.parse('/foo')).toBeNull();
+    });
+  });
+
+  describe('static canParse', () => {
+    it('returns true for an about:srcdoc base', () => {
+      expect(PatchedURL.canParse('/some-path', 'about:srcdoc')).toBe(true);
+    });
+
+    it('returns false for an invalid url', () => {
+      expect(PatchedURL.canParse('/foo')).toBe(false);
+    });
+  });
+});

--- a/packages/playground/src/front/js/utils/patch-iframe-url.ts
+++ b/packages/playground/src/front/js/utils/patch-iframe-url.ts
@@ -1,0 +1,48 @@
+/**
+ * The base URLs that resolve to no valid origin inside the preview iframe.
+ * A `srcdoc`/`about:blank` document reports one of these as `window.location.href`,
+ * which makes `new URL('/some-path', window.location.href)` throw an `Invalid URL`.
+ */
+const OPAQUE_BASES = new Set(['about:srcdoc', 'about:blank']);
+
+/**
+ * Rewrite an opaque iframe base (`about:srcdoc`, `about:blank`) to a real fallback base.
+ * Any other base is passed through untouched.
+ */
+function resolveBase(base: string | URL | undefined, fallback: string): string | URL | undefined {
+  if (base === undefined || base === null) {
+    return base;
+  }
+  return OPAQUE_BASES.has(String(base)) ? fallback : base;
+}
+
+/**
+ * Create a `URL` subclass that resolves opaque iframe bases against a real origin.
+ *
+ * `window.location` is `[LegacyUnforgeable]` and cannot be reassigned, so we cannot
+ * mock it directly. Instead we patch the iframe's `URL` global: whenever code passes
+ * the iframe's `about:srcdoc`/`about:blank` location as a base, it is transparently
+ * rewritten to `fallback` so `new URL('/some-path', window.location.href)` resolves
+ * as if the document were served from a real origin.
+ *
+ * @param NativeURL The iframe realm's native `URL` constructor.
+ * @param fallback  The base to substitute for opaque bases (defaults to `http://localhost/`).
+ */
+export function createPatchedUrl(
+  NativeURL: typeof URL,
+  fallback = 'http://localhost/',
+): typeof URL {
+  return class PatchedURL extends NativeURL {
+    constructor(url: string | URL, base?: string | URL) {
+      super(url, resolveBase(base, fallback));
+    }
+
+    static parse(url: string | URL, base?: string | URL): URL | null {
+      return NativeURL.parse(url, resolveBase(base, fallback));
+    }
+
+    static canParse(url: string | URL, base?: string | URL): boolean {
+      return NativeURL.canParse(url, resolveBase(base, fallback));
+    }
+  };
+}


### PR DESCRIPTION
## Problem

The preview iframe renders from `srcdoc`, so `window.location.href` inside it is `about:srcdoc`. Any consumer code that uses the current location as a base — the common `new URL('/some-path', window.location.href)` pattern — throws `Invalid URL`, because `about:srcdoc` (and `about:blank`) are opaque bases with no origin.

## Why not just mock `window.location`?

`window.location` is `[LegacyUnforgeable]` per the HTML spec — a non-configurable own property of `Window`. `Object.defineProperty(window, 'location', …)` (or shadowing it) throws in every browser, even for an iframe we fully control. Loading the iframe from a real URL (static asset or a Service Worker "virtual server") would work but is a much larger change; a Service Worker also can't fabricate an arbitrary origin and would have to be served at the right scope on every consumer's site.

## Fix

Patch the iframe realm's `URL` global instead. `createPatchedUrl()` returns a `URL` subclass whose constructor rewrites an `about:srcdoc`/`about:blank` base to a real origin (`http://localhost/`); every other base is passed through untouched. The static `URL.parse` / `URL.canParse` helpers get the same rewrite so the fix isn't partial. It's installed in `Iframe.initIframe()` before the user script is appended, so consumer code picks up the patched global.

```js
// inside the preview iframe, after this change:
new URL('/some-path', window.location.href).href
//   -> 'http://localhost/some-path'   (was: throws "Invalid URL")
```

Note: relative `fetch('/api')` already worked — a `srcdoc` document inherits `document.baseURI` from the parent (a real `http` URL). Only explicit use of the opaque location as a base was broken, which is exactly what this targets.

## Tests

TDD — `patch-iframe-url.test.ts` (12 cases) written first, covering the `srcdoc`/`blank`/`location`-object rewrites, custom fallback, pass-through of real bases, invalid-URL behavior, and `parse`/`canParse`. Full suite (94 tests), oxlint/stylelint/prettier, and `tsc` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHGYTjLU9Qk8FmTSfXhiKG