### PR TITLE
Pin modern-monaco's TypeScript worker compiler to the 6.x line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Pin the TypeScript compiler used by modern-monaco's editor worker to the 6.x line, fixing the worker failing to load since the TypeScript 7 release ([#72](https://github.com/studiometa/playground/pull/72), [d89092b](https://github.com/studiometa/playground/commit/d89092b))
+
 ## v0.3.9 - 2026.07.27
 
 ### Fixed

--- a/packages/playground/src/front/js/utils/monaco.ts
+++ b/packages/playground/src/front/js/utils/monaco.ts
@@ -78,6 +78,29 @@ function buildLspConfig(): InitOptions['lsp'] {
     Object.assign(merged, lsp);
   }
 
+  // Pin the TypeScript compiler loaded by modern-monaco's TS worker.
+  //
+  // modern-monaco declares `typescript: ">= 5.0.0"` as a peer dependency, so
+  // esm.sh bakes `import ts from "/typescript@>= 5.0.0"` into the worker it
+  // serves. That open-ended range now resolves to TypeScript 7.x, which esm.sh
+  // cannot build (`cjsModuleLexer: exit status 1`) — the request 500s, the
+  // module worker fails to load, and Monaco falls back to running the language
+  // service on the main thread (the "Could not create web worker(s)" warning).
+  //
+  // Override what modern-monaco requests via esm.sh's `&deps=` path segment,
+  // pinning the compiler to the 6.x line (the newest TypeScript esm.sh can
+  // build). We load the *deps-pinned* setup module so the pin propagates to the
+  // worker automatically: modern-monaco derives the worker URL from this
+  // module's `import.meta.url`, so `./worker.mjs` inherits the `&deps=` segment.
+  const tsSetupUrl = `https://esm.sh/modern-monaco@${__MODERN_MONACO_VERSION__}&deps=typescript@^6.0.0/es2022/lsp/typescript/setup.mjs`;
+  merged.providers = {
+    ...merged.providers,
+    typescript: {
+      aliases: ['javascript', 'jsx', 'tsx'],
+      import: () => import(/* webpackIgnore: true */ tsSetupUrl),
+    },
+  };
+
   // Override the HTML LSP provider to include template language aliases.
   // The import() must resolve to the same CDN-hosted HTML setup module
   // that modern-monaco uses internally. We build the URL using the same


### PR DESCRIPTION
## Problem

The playground editor started throwing console errors:

```
GET https://esm.sh/typescript@>= 5.0.0?target=es2022  — CORS Failed (status null)
Could not create web worker(s). Falling back to loading web worker code in main thread…
Uncaught error { target: Worker, … }
```

### Root cause

modern-monaco loads its TypeScript language-service worker from esm.sh. esm.sh bakes the worker's compiler import directly from modern-monaco's own peer dependency — `typescript: ">= 5.0.0"` — producing `import ts from "/typescript@>= 5.0.0"`.

That open-ended range now resolves to **TypeScript 7.x** (released, now the `latest` npm tag). **esm.sh cannot build TypeScript 7.x** — `https://esm.sh/typescript@7.0.2` returns `500 cjsModuleLexer(fallback mode): exit status 1`. The worker's import 500s → the module worker fails to load → Monaco falls back to the main thread and emits the errors above. TypeScript **6.0.3** builds fine.

This wasn't a config change on our side — it broke when TypeScript 7.0 became the newest release. Upgrading modern-monaco doesn't help (0.4.2 pins `>= 6.0.0`, still catches TS 7).

## Fix

Override the `typescript` LSP provider in `buildLspConfig()` (mirroring the existing `html` provider override) to load modern-monaco's setup module through esm.sh's `&deps=` **path** segment, which overrides what modern-monaco requests:

```
https://esm.sh/modern-monaco@${version}&deps=typescript@^6.0.0/es2022/lsp/typescript/setup.mjs
```

Because modern-monaco derives the worker URL from `import.meta.url` of that setup module, the `&deps=` pin propagates to `./worker.mjs` automatically. The served worker then bakes the buildable `import ts from "/typescript@6.0.3/es2022/typescript.mjs"`. The builtin `aliases: ["javascript","jsx","tsx"]` are preserved.

> Note: the `&deps=` **path** form is required — the `?deps=` **query** form is ignored by esm.sh for the pre-built worker.

## Verification

Confirmed live in the built demo preview via headless Chromium DevTools inspection:

- TS worker chain all `200`, compiler loads as **`typescript@6.0.3`** (not the 500ing `>= 5.0.0`→7.x)
- **No console errors or warnings** — CORS + "Could not create web worker(s)" gone
- Web workers created off-main-thread as intended

`npm run lint`, `tsc --build`, package + demo builds, and the 94 node-project tests all pass.

## Follow-up

Worth reporting upstream so modern-monaco caps its `typescript` peer dependency below 7 (or esm.sh gains TS 7 build support).