### PR TITLE
Emit code-split dependency chunks without filename collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Emit code-split self-hosted dependency chunks without filename collision — a dependency that uses a dynamic `import()` no longer aborts the webpack build with `Conflict: Multiple assets emit different content to the same filename static/deps/<specifier>/index.js` ([#73](https://github.com/studiometa/playground/pull/73), [39fbb2c](https://github.com/studiometa/playground/commit/39fbb2c))
+
 ## v0.3.10 - 2026.07.27
 
 ### Fixed

--- a/packages/playground/src/lib/plugins/PlaygroundDependenciesPlugin.test.ts
+++ b/packages/playground/src/lib/plugins/PlaygroundDependenciesPlugin.test.ts
@@ -287,4 +287,154 @@ describe('PlaygroundDependenciesPlugin', () => {
       expect(fileDeps.size).toBe(0);
     });
   });
+
+  describe('emitBundleChunks', () => {
+    interface FakeChunk {
+      fileName: string;
+      code?: string;
+      isEntry?: boolean;
+    }
+
+    /**
+     * Call the private `emitBundleChunks` method with a fake compilation that
+     * records every emitted asset, mirroring how `processBundle` feeds tsdown
+     * build results into webpack. Returns a `path -> code` map of emitted
+     * assets, throwing if the same path is emitted twice (the regression the
+     * multi-chunk fix guards against).
+     */
+    function emitAndCollect(chunks: FakeChunk[], outputBase: string): Map<string, string> {
+      const emitted = new Map<string, string>();
+      const fakeCompilation = {
+        compiler: {
+          webpack: {
+            sources: {
+              RawSource: class {
+                value: string;
+                constructor(value: string) {
+                  this.value = value;
+                }
+              },
+            },
+          },
+        },
+        emitAsset(assetPath: string, source: { value: string }) {
+          if (emitted.has(assetPath)) {
+            throw new Error(`Conflict: multiple assets emit to the same filename ${assetPath}`);
+          }
+          emitted.set(assetPath, source.value);
+        },
+      };
+
+      (plugin as any).emitBundleChunks(fakeCompilation, [{ chunks }], outputBase);
+
+      return emitted;
+    }
+
+    it('emits a single-chunk build as index.js + index.d.ts (back-compat)', () => {
+      const emitted = emitAndCollect(
+        [
+          { fileName: 'entry.js', code: 'export const a = 1;', isEntry: true },
+          { fileName: 'entry.d.ts', code: 'export declare const a: number;', isEntry: true },
+        ],
+        'static/deps/demo-lib',
+      );
+
+      expect([...emitted.keys()].sort()).toEqual([
+        'static/deps/demo-lib/index.d.ts',
+        'static/deps/demo-lib/index.js',
+      ]);
+      expect(emitted.get('static/deps/demo-lib/index.js')).toBe('export const a = 1;');
+      expect(emitted.get('static/deps/demo-lib/index.d.ts')).toBe(
+        'export declare const a: number;',
+      );
+    });
+
+    it('pins the entry to index.js/index.d.ts and keeps sibling chunk names on a code-split build', () => {
+      const emitted = emitAndCollect(
+        [
+          {
+            fileName: 'entry.js',
+            code: "await import('./child-CGcNIa1l.js');",
+            isEntry: true,
+          },
+          { fileName: 'entry.d.ts', code: 'export declare const root: string;', isEntry: true },
+          { fileName: 'child-CGcNIa1l.js', code: 'export const child = 1;', isEntry: false },
+        ],
+        'static/deps/@studiometa/ui-mapbox',
+      );
+
+      const paths = [...emitted.keys()].sort();
+
+      // Exactly one entry index.js and one entry index.d.ts.
+      expect(paths.filter((p) => p.endsWith('/index.js'))).toEqual([
+        'static/deps/@studiometa/ui-mapbox/index.js',
+      ]);
+      expect(paths.filter((p) => p.endsWith('/index.d.ts'))).toEqual([
+        'static/deps/@studiometa/ui-mapbox/index.d.ts',
+      ]);
+
+      // The non-entry chunk keeps its own hashed filename, emitted as a sibling.
+      expect(emitted.has('static/deps/@studiometa/ui-mapbox/child-CGcNIa1l.js')).toBe(true);
+
+      // Three distinct paths — no two chunks collapse onto the same filename.
+      expect(paths.length).toBe(3);
+    });
+
+    it('does not collide when multiple non-entry chunks are emitted', () => {
+      // The previous implementation renamed every chunk to index.js, so a
+      // second non-entry chunk threw the webpack seal-time "Conflict" error.
+      expect(() =>
+        emitAndCollect(
+          [
+            { fileName: 'entry.js', code: 'entry', isEntry: true },
+            { fileName: 'entry.d.ts', code: 'entry types', isEntry: true },
+            { fileName: 'child-aaaaaaaa.js', code: 'child a', isEntry: false },
+            { fileName: 'child-bbbbbbbb.js', code: 'child b', isEntry: false },
+          ],
+          'static/deps/multi',
+        ),
+      ).not.toThrow();
+    });
+
+    it('emits non-entry .d.ts chunks under their own name', () => {
+      const emitted = emitAndCollect(
+        [
+          { fileName: 'entry.js', code: 'entry', isEntry: true },
+          { fileName: 'entry.d.ts', code: 'entry types', isEntry: true },
+          { fileName: 'child-aaaaaaaa.js', code: 'child', isEntry: false },
+          { fileName: 'child-aaaaaaaa.d.ts', code: 'child types', isEntry: false },
+        ],
+        'static/deps/multi',
+      );
+
+      expect(emitted.has('static/deps/multi/child-aaaaaaaa.d.ts')).toBe(true);
+      // The single entry dts is still pinned to index.d.ts.
+      expect(emitted.get('static/deps/multi/index.d.ts')).toBe('entry types');
+    });
+
+    it('keeps the import map / _headers pointing at .../index.js and .../index.d.ts', () => {
+      // The import map value and the _headers x-typescript-types entry are both
+      // derived from the specifier as `.../index.js` and `.../index.d.ts`. The
+      // emit path must keep those exact entry filenames stable even when the
+      // dependency code-splits.
+      const specifier = '@studiometa/ui-mapbox';
+      const outputBase = `static/deps/${specifier}`;
+      const emitted = emitAndCollect(
+        [
+          { fileName: 'entry.js', code: 'entry', isEntry: true },
+          { fileName: 'entry.d.ts', code: 'types', isEntry: true },
+          { fileName: 'child-CGcNIa1l.js', code: 'child', isEntry: false },
+        ],
+        outputBase,
+      );
+
+      const importMapValue = `/static/deps/${specifier}/index.js`;
+      const headersJsPath = `/static/deps/${specifier}/index.js`;
+      const headersDtsPath = `/static/deps/${specifier}/index.d.ts`;
+
+      expect(emitted.has(importMapValue.replace(/^\//, ''))).toBe(true);
+      expect(emitted.has(headersJsPath.replace(/^\//, ''))).toBe(true);
+      expect(emitted.has(headersDtsPath.replace(/^\//, ''))).toBe(true);
+    });
+  });
 });

--- a/packages/playground/src/lib/plugins/PlaygroundDependenciesPlugin.ts
+++ b/packages/playground/src/lib/plugins/PlaygroundDependenciesPlugin.ts
@@ -8,9 +8,11 @@ import { resolvePublicPath } from '../utils/resolve-public-path.js';
 /**
  * Webpack plugin that processes self-hosted playground dependencies.
  *
- * Every dependency with a `source` is bundled into a single `.js` + `.d.ts`
- * using tsdown (rolldown + rolldown-plugin-dts). Works with both npm packages
- * and local TypeScript sources.
+ * Every dependency with a `source` is bundled with tsdown (rolldown +
+ * rolldown-plugin-dts). The entry is emitted as `index.js` + `index.d.ts`;
+ * when the dependency code-splits via dynamic `import()`, the extra chunks are
+ * emitted alongside under their own content-hashed filenames. Works with both
+ * npm packages and local TypeScript sources.
  */
 export class PlaygroundDependenciesPlugin {
   dependencies: ResolvedDependency[];
@@ -127,7 +129,8 @@ export class PlaygroundDependenciesPlugin {
   }
 
   /**
-   * Bundle a dependency into a single `.js` + `.d.ts` using tsdown.
+   * Bundle a dependency into `index.js` + `index.d.ts` (plus any code-split
+   * sibling chunks) using tsdown.
    *
    * For npm packages, a temporary re-export entry file is created so that
    * tsdown can resolve the package from the consumer's `node_modules`.
@@ -173,24 +176,57 @@ export class PlaygroundDependenciesPlugin {
         external,
       });
 
-      for (const buildResult of buildResults) {
-        for (const chunk of buildResult.chunks) {
-          if ('code' in chunk) {
-            const fileName = chunk.fileName.endsWith('.d.ts') ? 'index.d.ts' : 'index.js';
-            const assetPath = posix.join(outputBase, fileName);
-            compilation.emitAsset(
-              assetPath,
-              new compilation.compiler.webpack.sources.RawSource(chunk.code),
-            );
-          }
-        }
-      }
+      this.emitBundleChunks(compilation, buildResults, outputBase);
     } finally {
       if (isNpmSource) {
         try {
           rmSync(dirname(entryPoint), { recursive: true, force: true });
         } catch {
           // ignore
+        }
+      }
+    }
+  }
+
+  /**
+   * Emit every chunk of a tsdown build result as a webpack asset under
+   * `outputBase`.
+   *
+   * The entry chunks are pinned to the stable `index.js` / `index.d.ts`
+   * filenames because the import map (see `resolve-dependencies.ts`) and the
+   * `_headers` file both point at `.../index.js` and `.../index.d.ts` — that
+   * contract must not change.
+   *
+   * Every non-entry chunk (produced when a dependency code-splits via a
+   * dynamic `import()`, e.g. `@studiometa/ui-mapbox`'s lazy `MapboxMap`
+   * children) keeps its real, content-hashed filename. The entry chunk's
+   * internal `import('./child-<hash>.js')` calls are relative, so those
+   * chunks resolve as siblings in the same emitted directory — no import map
+   * or runtime change is required.
+   *
+   * Renaming every chunk to `index.js` (the previous behaviour, which assumed
+   * a single-chunk bundle) collapses all non-entry chunks onto the same path
+   * and makes webpack abort at seal time with:
+   * `Conflict: Multiple assets emit different content to the same filename
+   * static/deps/<specifier>/index.js`.
+   *
+   * @private
+   */
+  private emitBundleChunks(
+    compilation: any,
+    buildResults: Array<{ chunks: Array<{ fileName: string; code?: string; isEntry?: boolean }> }>,
+    outputBase: string,
+  ) {
+    for (const buildResult of buildResults) {
+      for (const chunk of buildResult.chunks) {
+        if ('code' in chunk && typeof chunk.code === 'string') {
+          const isDts = chunk.fileName.endsWith('.d.ts');
+          const fileName = chunk.isEntry ? (isDts ? 'index.d.ts' : 'index.js') : chunk.fileName;
+          const assetPath = posix.join(outputBase, fileName);
+          compilation.emitAsset(
+            assetPath,
+            new compilation.compiler.webpack.sources.RawSource(chunk.code),
+          );
         }
       }
     }


### PR DESCRIPTION
## The bug

`PlaygroundDependenciesPlugin.processBundle()` renamed **every** emitted tsdown chunk to a fixed `index.js` / `index.d.ts`:

```ts
const fileName = chunk.fileName.endsWith('.d.ts') ? 'index.d.ts' : 'index.js';
```

This assumed each self-hosted dependency bundled into a single chunk. When a dependency code-splits via a dynamic `import()`, tsdown/rolldown emits several chunks and the non-entry ones all collapsed onto the same `index.js` path, so webpack aborts at seal time with:

```
Conflict: Multiple assets emit different content to the same filename static/deps/<specifier>/index.js
```

**Downstream trigger:** [studiometa/ui#566](https://github.com/studiometa/ui/pull/566) makes `@studiometa/ui-mapbox` code-split by lazy-loading `MapboxMap`'s child components via dynamic `import()`, which is what surfaced this in the playground.

## The fix

Pin **only the entry chunk** to the stable `index.js` / `index.d.ts` filenames — the import map (`resolve-dependencies.ts`) and the `_headers` `x-typescript-types` entry both point at `.../index.js` and `.../index.d.ts`, so the entry name must stay stable. Every **non-entry** chunk is now emitted under its own content-hashed filename:

```ts
const isDts = chunk.fileName.endsWith('.d.ts');
const fileName = chunk.isEntry ? (isDts ? 'index.d.ts' : 'index.js') : chunk.fileName;
```

The entry chunk's internal `import('./child-<hash>.js')` calls are relative, so the sibling chunks resolve in the same emitted directory — no import-map or runtime change is needed. Single-chunk dependencies (the common case) still emit exactly `index.js` + `index.d.ts`, byte-identical to before.

### Why `isEntry` and not build `outputOptions`

I verified empirically against tsdown 0.21.1 (the pinned version) with a code-split fixture — even when the entry file is not named `index.ts` (the npm-package path uses a temp `entry.ts`): `isEntry` is reliably `true` on **both** the JS and the `.d.ts` entry chunks, and `false` on the dynamic child chunk. So the minimal `isEntry` check is correct and there's no need to force names via the `tsdown.build()` call.

```
{ fileName: 'entry.d.ts',         isEntry: true }
{ fileName: 'entry.js',           isEntry: true }
{ fileName: 'child-CGcNIa1l.js',  isEntry: false, isDynamicEntry: true }
```

## Test coverage

The emit path was previously untested. Extracted the emit loop into `emitBundleChunks()` and added unit tests:

- **single-chunk build** → still emits exactly `.../index.js` + `.../index.d.ts` (back-compat)
- **code-split build** → exactly one `.../index.js` and one `.../index.d.ts`, non-entry chunk kept under its own name, three distinct paths
- **multiple non-entry chunks** → regression guard asserting no two chunks emit to the same path (the reported webpack conflict)
- non-entry `.d.ts` chunks emitted under their own name
- import map value / `_headers` paths still reference `.../index.js` and `.../index.d.ts`

## Verification

- `npm run test` — 129 passed
- `npm run build --workspace=@studiometa/playground` (incl. `tsc`) — passes
- `oxlint` + `prettier -c` — clean
- End-to-end: ran the real `processBundle` (real tsdown build) against a dynamic-import fixture; it now emits `index.js`, `index.d.ts`, and the sibling `child-CGcNIa1l.js` with no collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NeZwHwo3d9rYsCxJUQqTep