### PR TITLE
Fix virtual loader resolution under enhanced-resolve >= 5.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Write the virtual HTML/style/script loader modules at the package's resolved on-disk root instead of a path relative to the webpack compiler context, so the bare `@studiometa/playground/<name>-loader.js` imports resolve. These specifiers go through the package's `"./*": "./*"` exports entry, and since enhanced-resolve >= 5.21 (webpack/enhanced-resolve#399) a matched exports target that is missing on disk is a hard error instead of falling back to legacy resolution — so consumer builds on webpack 5.109+ failed with `Package path ./html-loader.js is exported from package ... but no valid target file was found`
+
 ## v0.3.13 - 2026.08.06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- Write the virtual HTML/style/script loader modules at the package's resolved on-disk root instead of a path relative to the webpack compiler context, so the bare `@studiometa/playground/<name>-loader.js` imports resolve. These specifiers go through the package's `"./*": "./*"` exports entry, and since enhanced-resolve >= 5.21 (webpack/enhanced-resolve#399) a matched exports target that is missing on disk is a hard error instead of falling back to legacy resolution — so consumer builds on webpack 5.109+ failed with `Package path ./html-loader.js is exported from package ... but no valid target file was found`
+- Write the virtual HTML/style/script loader modules at the package's resolved on-disk root instead of a path relative to the webpack compiler context, so the bare `@studiometa/playground/<name>-loader.js` imports resolve. These specifiers go through the package's `"./*": "./*"` exports entry, and since enhanced-resolve >= 5.21 (webpack/enhanced-resolve#399) a matched exports target that is missing on disk is a hard error instead of falling back to legacy resolution — so consumer builds on webpack 5.109+ failed with `Package path ./html-loader.js is exported from package ... but no valid target file was found` ([#77](https://github.com/studiometa/playground/pull/77), [d0c924a](https://github.com/studiometa/playground/commit/d0c924a))
 
 ## v0.3.13 - 2026.08.06
 

--- a/packages/playground/src/lib/plugins/PlaygroundLoadersPlugin.ts
+++ b/packages/playground/src/lib/plugins/PlaygroundLoadersPlugin.ts
@@ -1,4 +1,6 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname } from 'node:path';
 import type { Compiler } from 'webpack';
 import VirtualModulesPlugin from 'webpack-virtual-modules';
 
@@ -25,13 +27,23 @@ export class PlaygroundLoadersPlugin {
     const virtualModulesConfig = {};
     const defaultLoader = 'export default async function loader(value) { return value };';
 
+    // The loaders are imported through the bare `@studiometa/playground/<name>-loader.js`
+    // specifiers, which webpack resolves via the package's `"./*": "./*"` exports entry to
+    // this package's real on-disk root. Since enhanced-resolve >= 5.21 (webpack/enhanced-resolve#399),
+    // a matched exports target that does not exist on disk is a hard error instead of falling back
+    // to legacy resolution. So the virtual files MUST be written at the package's resolved root; a
+    // path relative to the compiler context lands under the consumer app and no longer resolves.
+    const require = createRequire(import.meta.url);
+    const packageRoot = realpathSync(
+      dirname(require.resolve('@studiometa/playground/package.json')),
+    );
+
     for (const loaderName of this.loaderNames) {
       const loaderContent =
         this.loaders && this.loaders[loaderName] && existsSync(this.loaders[loaderName])
           ? readFileSync(this.loaders[loaderName])
           : defaultLoader;
-      virtualModulesConfig[`node_modules/@studiometa/playground/${loaderName}-loader.js`] =
-        loaderContent;
+      virtualModulesConfig[`${packageRoot}/${loaderName}-loader.js`] = loaderContent;
     }
 
     const virtualModules = new VirtualModulesPlugin(virtualModulesConfig);


### PR DESCRIPTION
## Problem

Consumer builds on webpack 5.109+ (enhanced-resolve 5.24.5) fail with:

```
Module not found: Error: Package path ./html-loader.js is exported from package .../@studiometa/playground, but no valid target file was found (see exports field ...)
```

(and the same for `style-loader.js` and `script-loader.js`).

## Root cause

`PlaygroundLoadersPlugin` registers the three virtual loader modules with `webpack-virtual-modules` using keys **relative** to the compiler context:

```
node_modules/@studiometa/playground/<name>-loader.js
```

`webpack-virtual-modules` joins each relative key against `compiler.context` (the consumer app's build context), so the virtual files land under `<consumer-context>/node_modules/@studiometa/playground/`.

But `config.ts` imports the **bare** specifiers `@studiometa/playground/<name>-loader.js`. Webpack resolves those through the package's `"./*": "./*"` exports entry to the package's **real resolved root** — a different path than where the virtual files were written.

This used to work only by accident: enhanced-resolve <= 5.20 fell back to legacy resolution when an `exports` target was matched but missing on disk. enhanced-resolve >= 5.21 (webpack/enhanced-resolve#399, #400) changed that matched-but-missing case into a **hard error**. After webpack bumped to 5.109.x, the fallback disappeared and the loaders no longer resolve.

## Fix

Write the virtual loaders at the package's **actual resolved on-disk root** (absolute path via `createRequire(import.meta.url).resolve('@studiometa/playground/package.json')`) instead of a path relative to the compiler context, so the `exports`-field target resolves to a real (virtual) file.

## Validation

- `npm run build:esbuild` and `npm run build:types` succeed, types check clean.
- `oxlint` reports 0 warnings / 0 errors on the changed file.
- Full `vitest` suite: 153 tests pass.
- Validated end to end against a consumer build: patched the resolved logic into `@studiometa/ui`'s playground `play:build` (webpack 5.109.x / enhanced-resolve 5.24.5) and the build that previously errored now completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKLcgvaDcjK9ohA3fg7Ssq